### PR TITLE
CMake clean up; modern g2o and mrpt targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# for in-tree builds:
+build
+3rdparty/DBoW2/lib/*
+3rdparty/line_descriptor/lib/*
+lib/*
+
+
+# for qtcreator IDE
+CMakeLists.txt.user*
+

--- a/3rdparty/line_descriptor/CMakeLists.txt
+++ b/3rdparty/line_descriptor/CMakeLists.txt
@@ -18,10 +18,10 @@ set(LIBRARY_OUTPUT_PATH    ${PROJECT_SOURCE_DIR}/lib)
 
 include_directories( include ${OpenCV_INCLUDE_DIRS} )
 list(APPEND LINK_LIBS ${OpenCV_LIBS} )
-file(GLOB_RECURSE all_include_files RELATIVE "${CMAKE_SOURCE_DIR}" *.h *.hpp)
+file(GLOB_RECURSE all_include_files RELATIVE "${PROJECT_SOURCE_DIR}" *.h *.hpp)
 
 link_directories(${CMAKE_SOURCE_DIR}/src/)
-file(GLOB_RECURSE all_source_files RELATIVE "${CMAKE_SOURCE_DIR}src/" *.cpp )
+file(GLOB_RECURSE all_source_files RELATIVE "${PROJECT_SOURCE_DIR}src/" *.cpp )
 
 add_custom_target( linedesc_includes DEPENDS ${all_include_files} SOURCES ${all_source_files} )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,28 @@
-project( PL-SLAM )
-
+project(PL-SLAM)
 cmake_minimum_required(VERSION 2.7)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake_modules")
 
+add_subdirectory(3rdparty/line_descriptor)
+add_subdirectory(3rdparty/DBoW2)
+
+set(HAS_MRPT ON CACHE BOOL "Build the PointGrey Bumblebee2 SVO application that employs the MRPT library")
+
 find_package(OpenCV 3 REQUIRED)
-find_package(Boost REQUIRED COMPONENTS regex thread system filesystem)
-find_package(G2O      REQUIRED)
+find_package(Boost    REQUIRED COMPONENTS regex thread system filesystem)
+find_package(g2o      REQUIRED)
 find_package(Eigen3   REQUIRED)
+find_package(yaml-cpp REQUIRED CONFIG PATHS ${YAML_PATHS}) # YAML library
+
+# MRPT library (optional, only with representation purposes)
+if(HAS_MRPT)
+    find_package(MRPT 1.9.9 REQUIRED opengl gui hwdrivers)
+    add_definitions(-DHAS_MRPT)
+endif()
 
 if(COMMAND cmake_policy)
   	cmake_policy(SET CMP0003 NEW)	
-endif(COMMAND cmake_policy)
+endif()
 link_directories(${OpenCV_LIBS_DIR})
 include_directories(${OpenCV2_INCLUDE_DIRS})
 
@@ -19,8 +30,6 @@ include_directories(${OpenCV2_INCLUDE_DIRS})
 SET( StVO_LIBRARY 		"" CACHE FILEPATH "Visual Odometry Library" )
 SET( StVO_INCLUDE_DIR 	"" CACHE PATH "Visual Odometry Include folder" )	
 
-set(DEFAULT_HAS_MRPT ON)
-set(HAS_MRPT ${DEFAULT_HAS_MRPT} CACHE BOOL "Build the PointGrey Bumblebee2 SVO application that employs the MRPT library")
 
 SET(BUILD_SHARED_LIBS ON)
 SET(CMAKE_MODULE_PATH $ENV{CMAKE_MODULE_PATH})
@@ -28,21 +37,15 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3 -mtune=native -march=nati
 
 add_definitions(-DBOOST_NO_CXX11_SCOPED_ENUMS)
 
-# MRPT library (optional, only with representation purposes)
-if(HAS_MRPT)
-FIND_PACKAGE(MRPT REQUIRED base opengl gui hwdrivers)
-set(MRPT_DONT_USE_DBG_LIBS 1) #use release libraries for linking even if "Debug" CMake build
-add_definitions(-DHAS_MRPT)
-endif(HAS_MRPT)
-
-
-# YAML library
-FIND_PACKAGE(yaml-cpp REQUIRED CONFIG PATHS ${YAML_PATHS})
-
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/build)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
-SET(G2O_LIBS g2o_cli g2o_ext_freeglut_minimal g2o_simulator g2o_solver_slam2d_linear g2o_types_icp g2o_types_slam2d g2o_core g2o_interface g2o_solver_csparse g2o_solver_structure_only g2o_types_sba g2o_types_slam3d g2o_csparse_extension g2o_opengl_helper g2o_solver_dense g2o_stuff g2o_types_sclam2d g2o_parser g2o_solver_pcg g2o_types_data g2o_types_sim3 cxsparse g2o_ext_csparse cholmod )
+SET(G2O_LIBS
+    g2o::core
+    g2o::types_slam2d
+    g2o::types_slam3d
+    g2o::solver_cholmod
+    )
 
 # Include dirs
 include_directories(
@@ -55,8 +58,10 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/3rdparty/DBoW2/include/
   ${PROJECT_SOURCE_DIR}/3rdparty/line_descriptor/include/
   ${G2O_INCLUDE_DIR}
+  ${g2o_INCLUDE_DIR}
   /usr/include/suitesparse # for cholmod
 )
+
 
 # Set link libraries
 list(APPEND LINK_LIBS 
@@ -65,26 +70,22 @@ list(APPEND LINK_LIBS
   ${YAML_CPP_LIBRARIES}
   ${G2O_LIBS}
   ${PROJECT_SOURCE_DIR}/../stvo-pl/lib/libstvo.so
-  ${PROJECT_SOURCE_DIR}/3rdparty/DBoW2/lib/libDBoW2.so
-  ${PROJECT_SOURCE_DIR}/3rdparty/line_descriptor/lib/liblinedesc.so
+  DBoW2
+  linedesc
+)
+
+list(APPEND SOURCEFILES
+  src/mapHandler.cpp
+  src/mapFeatures.cpp
+  src/keyFrame.cpp
+  src/slamConfig.cpp
 )
 
 # Set source files 
 if(HAS_MRPT)
-list(APPEND SOURCEFILES
-  src/mapHandler.cpp
-  src/mapFeatures.cpp
-  src/keyFrame.cpp
-  src/slamConfig.cpp
-  src/slamScene.cpp
-)
-else()
-list(APPEND SOURCEFILES
-  src/mapHandler.cpp
-  src/mapFeatures.cpp
-  src/keyFrame.cpp
-  src/slamConfig.cpp
-)
+    list(APPEND SOURCEFILES
+        src/slamScene.cpp
+    )
 endif()
 
 # List all files (headers) contained by StVO-PL library
@@ -96,17 +97,17 @@ add_custom_target( plslam_includes DEPENDS ${all_include_files} SOURCES ${all_in
 # Create StVO-PL library
 add_library(plslam SHARED ${SOURCEFILES})
 
-if(HAS_MRPT)
-target_link_libraries(plslam ${LINK_LIBS} ${MRPT_LIBS}  )
-else()
 target_link_libraries(plslam ${LINK_LIBS})
+
+if(HAS_MRPT)
+    target_link_libraries(plslam ${MRPT_LIBS} ${MRPT_LIBRARIES})
 endif()
 
 # Applications 
 if(HAS_MRPT)
-add_executable       ( plslam_dataset app/plslam_dataset.cpp )
-target_link_libraries( plslam_dataset plslam )
-endif(HAS_MRPT)
+    add_executable       ( plslam_dataset app/plslam_dataset.cpp )
+    target_link_libraries( plslam_dataset plslam )
+endif()
 
 
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,18 @@ https://github.com/rubengooj/stvo-pl
 ```
 
 ### MRPT (>=v1.9.9)
-In case of using the provided representation class.
-Download and install instructions can be found at: https://www.mrpt.org/
-Either:
-- (recommended) Install [from this PPA](https://launchpad.net/~joseluisblancoc/+archive/ubuntu/mrpt).
-- or build [from sources](https://github.com/mrpt/mrpt/).
+Optional: Enables the provided visualization class.
+
+1) Only for Ubuntu 16.04 Xenial: upgrade gcc. Instructions [here](https://gist.github.com/jlblancoc/99521194aba975286c80f93e47966dc5).
+2) For any Ubuntu version older than 20.04 Focal:
+```
+sudo add-apt-repository ppa:joseluisblancoc/mrpt
+sudo apt-get update
+```
+3) Everyone: Install mrpt libraries:
+```
+sudo apt-get install libmrpt-dev
+```
 
 ### Line Descriptor
 We have modified the [*line_descriptor*](https://github.com/opencv/opencv_contrib/tree/master/modules/line_descriptor) module from the [OpenCV/contrib](https://github.com/opencv/opencv_contrib) library (both BSD) which is included in the *3rdparty* folder.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please do not hesitate to contact the authors if you have any further questions.
 ## 1. Prerequisites and dependencies
 
 ### OpenCV 3.x.x
-It can be easily found at http://opencv.org. 
+It can be easily found at http://opencv.org.
 
 ### Eigen3 (tested with 3.2.92)
 http://eigen.tuxfamily.org
@@ -61,20 +61,17 @@ sudo apt-get install libyaml-cpp-dev
 ```
 
 ### stvo-pl
-It can be found at: 
+It can be found at:
 ```
 https://github.com/rubengooj/stvo-pl
 ```
 
-### MRPT
-In case of using the provided representation class. 
-Download and install instructions can be found at: http://www.mrpt.org/
-
-#### Known Issues:
-If working with the most recent versions of the MRPT library you might find some issues due to hard refactoring, for which we recommend to use this version instead (the last one we tested):
-```
-https://github.com/MRPT/mrpt/tree/0c3d605c3cbf5f2ffb8137089e43ebdae5a55de3
-```
+### MRPT (>=v1.9.9)
+In case of using the provided representation class.
+Download and install instructions can be found at: https://www.mrpt.org/
+Either:
+- (recommended) Install [from this PPA](https://launchpad.net/~joseluisblancoc/+archive/ubuntu/mrpt).
+- or build [from sources](https://github.com/mrpt/mrpt/).
 
 ### Line Descriptor
 We have modified the [*line_descriptor*](https://github.com/opencv/opencv_contrib/tree/master/modules/line_descriptor) module from the [OpenCV/contrib](https://github.com/opencv/opencv_contrib) library (both BSD) which is included in the *3rdparty* folder.
@@ -106,4 +103,3 @@ A full command would be:
 ./plslam_dataset kitti/00 -c ../config/config_kitti.yaml -o 100 -s 2 -n 1000
 
 where we are processing the sequence 00 from the KITTI dataset (in our dataset folders) with the custom config file, with an offset *-c* allowing to skip the first 100 images, a parameter *-s* to consider only one every 2 images, and a parameter *-n* to only consider 1000 input pairs.
-

--- a/build.sh
+++ b/build.sh
@@ -1,19 +1,3 @@
-echo "Building 3rdparty/line_descriptor ... "
-cd 3rdparty/line_descriptor
-mkdir build
-cd build
-cmake ..
-make -j8
-cd ../../../
-
-echo "Building 3rdparty/DBoW2 ... "
-cd 3rdparty/DBoW2
-mkdir build
-cd build
-cmake ..
-make -j8
-cd ../../../
-
 echo "Uncompressing vocabulary ..."
 cd vocabulary
 tar -xf voc.tar.gz

--- a/include/slamScene.h
+++ b/include/slamScene.h
@@ -26,12 +26,12 @@ using namespace std;
 #include <mrpt/opengl.h>
 #include <mrpt/opengl/CPointCloudColoured.h>
 #include <mrpt/gui.h>
-#include <mrpt/utils/CConfigFile.h>
-#include <mrpt/utils/CConfigFileBase.h>
+#include <mrpt/config/CConfigFile.h>
+#include <mrpt/config/CConfigFileBase.h>
 using namespace mrpt;
 using namespace mrpt::gui;
 using namespace mrpt::poses;
-using namespace mrpt::utils;
+using namespace mrpt::config;
 using namespace mrpt::math;
 using namespace mrpt::opengl;
 
@@ -89,20 +89,19 @@ public:
     CPose3D getPoseXYZ(VectorXd x);
 
     CDisplayWindow3D*           win;
-    COpenGLScenePtr             theScene;
-    COpenGLViewportPtr          image, legend, help;
-    opengl::CSetOfObjectsPtr    bbObj, bbObj1, srefObj, srefObj1, gtObj, srefObjGT, elliObjL, elliObjP;
-    opengl::CEllipsoidPtr       elliObj;
-    opengl::CFrustumPtr         frustObj, frustObj1;
-    opengl::CAxisPtr            axesObj;
+    COpenGLScene::Ptr             theScene;
+    COpenGLViewport::Ptr          image, legend, help;
+    opengl::CSetOfObjects::Ptr    bbObj, bbObj1, srefObj, srefObj1, gtObj, srefObjGT, elliObjL, elliObjP;
+    opengl::CEllipsoid::Ptr       elliObj;
+    opengl::CFrustum::Ptr         frustObj, frustObj1;
+    opengl::CAxis::Ptr            axesObj;
 
-    opengl::CSetOfLinesPtr      lineObj, lineObj_local, kfsLinesObj, voLinesObj;
-    opengl::CPointCloudPtr      pointObj, pointObj_local;
-    opengl::CSetOfObjectsPtr    kfsObj;
-
+    opengl::CSetOfLines::Ptr      lineObj, lineObj_local, kfsLinesObj, voLinesObj;
+    opengl::CPointCloud::Ptr      pointObj, pointObj_local;
+    opengl::CSetOfObjects::Ptr    kfsObj;
 
     float           sbb, saxis, srad, sref, sline, sfreq, szoom, selli, selev, sazim, sfrust, slinef;
-    CVectorDouble   v_aux, v_aux_, v_aux1, v_aux1_, v_auxgt, gt_aux_, v_auxgt_;
+    CVectorFixedDouble<6> v_aux, v_aux_, v_aux1, v_aux1_, v_auxgt, gt_aux_, v_auxgt_;
     CPose3D         pose, pose_0, pose_gt, pose_ini, ellPose, pose1,  change, frustumL_, frustumR_;
     Matrix4d        x_ini;
     mrptKeyModifier kmods;
@@ -116,7 +115,7 @@ public:
     float           time;
     string          img, img_legend, img_help;
     CMatrixFloat    lData, pData;
-    CImage          img_mrpt_legend, img_mrpt_image, img_mrpt_help;
+    mrpt::img::CImage img_mrpt_legend, img_mrpt_image, img_mrpt_help;
 
     float           b, sigmaP, sigmaL, f, cx, cy, bsigmaL, bsigmaP;
 

--- a/src/mapHandler.cpp
+++ b/src/mapHandler.cpp
@@ -3962,10 +3962,10 @@ bool MapHandler::loopClosureOptimizationEssGraphG2O()
     // define G2O variables
     g2o::SparseOptimizer optimizer;
     optimizer.setVerbose(true);
-    g2o::BlockSolver_6_3::LinearSolverType* linearSolver;
-    linearSolver = new g2o::LinearSolverCholmod<g2o::BlockSolver_6_3::PoseMatrixType>();
-    g2o::BlockSolver_6_3* solver_ptr = new g2o::BlockSolver_6_3(linearSolver);
-    g2o::OptimizationAlgorithmLevenberg* solver = new g2o::OptimizationAlgorithmLevenberg(solver_ptr);
+
+    std::unique_ptr<g2o::BlockSolver_6_3::LinearSolverType> linearSolver (new g2o::LinearSolverCholmod<g2o::BlockSolver_6_3::PoseMatrixType>());
+    std::unique_ptr<g2o::BlockSolver_6_3> solver_ptr (new g2o::BlockSolver_6_3(std::move(linearSolver)));
+    g2o::OptimizationAlgorithmLevenberg * solver = new g2o::OptimizationAlgorithmLevenberg(std::move(solver_ptr));
     solver->setUserLambdaInit(1e-10);
     optimizer.setAlgorithm(solver);
 
@@ -4188,10 +4188,10 @@ bool MapHandler::loopClosureOptimizationCovGraphG2O()
     // define G2O variables
     g2o::SparseOptimizer optimizer;
     optimizer.setVerbose(false);
-    g2o::BlockSolver_6_3::LinearSolverType* linearSolver;
-    linearSolver = new g2o::LinearSolverCholmod<g2o::BlockSolver_6_3::PoseMatrixType>();
-    g2o::BlockSolver_6_3* solver_ptr = new g2o::BlockSolver_6_3(linearSolver);
-    g2o::OptimizationAlgorithmLevenberg* solver = new g2o::OptimizationAlgorithmLevenberg(solver_ptr);
+    
+    std::unique_ptr<g2o::BlockSolver_6_3::LinearSolverType> linearSolver (new g2o::LinearSolverCholmod<g2o::BlockSolver_6_3::PoseMatrixType>());
+    std::unique_ptr<g2o::BlockSolver_6_3> solver_ptr (new g2o::BlockSolver_6_3(std::move(linearSolver)));
+    g2o::OptimizationAlgorithmLevenberg * solver = new g2o::OptimizationAlgorithmLevenberg(std::move(solver_ptr));
     solver->setUserLambdaInit(1e-10);
     optimizer.setAlgorithm(solver);
 

--- a/src/slamScene.cpp
+++ b/src/slamScene.cpp
@@ -111,6 +111,9 @@ slamScene::~slamScene(){
 
 void slamScene::initializeScene(Matrix4d x_0){
 
+    using mrpt::img::TColor;
+    using mrpt::img::TColorf;
+
     // Initialize the scene and window
     win->setCameraElevationDeg(selev);
     win->setCameraAzimuthDeg(sazim);
@@ -124,9 +127,9 @@ void slamScene::initializeScene(Matrix4d x_0){
     pose_0  = x_aux;
     pose_gt = pose_ini;
     x_ini   = x_0;
-    pose.getAsVector(v_aux);
-    pose1.getAsVector(v_aux1);
-    pose_gt.getAsVector(v_auxgt);
+    pose.asVector(v_aux);
+    pose1.asVector(v_aux1);
+    pose_gt.asVector(v_auxgt);
 
     // Initialize the camera object
     frustumL_.setFromValues(0,0,0,  0, -90.f*CV_PI/180.f, -90.f*CV_PI/180.f);
@@ -216,6 +219,8 @@ void slamScene::initViewports(int W, int H){
 
 bool slamScene::updateScene(){
 
+    using mrpt::img::TColor;
+
     theScene = win->get3DSceneAndLock();
     bool restart = false;
 
@@ -227,7 +232,7 @@ bool slamScene::updateScene(){
         CPose3D x_aux1(getPoseFormat(x));
         pose = pose + x_aux1;
         v_aux_ = v_aux;
-        pose.getAsVector(v_aux);
+        pose.asVector(v_aux);
         frustObj  = opengl::CFrustum::Create();
         {
             frustObj->setPose(pose+frustumL_);
@@ -260,6 +265,8 @@ bool slamScene::updateScene(){
 
 bool slamScene::updateSceneVO( Matrix4d T_last_kf ){
 
+    using mrpt::img::TColor;
+
     theScene = win->get3DSceneAndLock();
     bool restart = false;
 
@@ -272,7 +279,7 @@ bool slamScene::updateSceneVO( Matrix4d T_last_kf ){
         CPose3D x_aux1(getPoseFormat(x));
         pose = pose + x_aux1;
         v_aux_ = v_aux;
-        pose.getAsVector(v_aux);
+        pose.asVector(v_aux);
         frustObj  = opengl::CFrustum::Create();
         {
             frustObj->setPose(pose+frustumL_);
@@ -305,6 +312,9 @@ bool slamScene::updateSceneVO( Matrix4d T_last_kf ){
 
 bool slamScene::updateScene(const MapHandler* map){
 
+    using mrpt::img::TColor;
+    using mrpt::img::TColorf;
+
     theScene = win->get3DSceneAndLock();
     bool restart = false;
 
@@ -330,7 +340,7 @@ bool slamScene::updateScene(const MapHandler* map){
             if( (*it)->kf_idx == map->map_keyframes.back()->kf_idx )
             {
                 kf_pose = CPose3D( getPoseFormat( (*it)->T_kf_w ) );
-                opengl::CFrustumPtr frust_ = opengl::CFrustum::Create();
+                auto frust_ = opengl::CFrustum::Create();
                 {
                     frust_->setPose( kf_pose + frustumL_ );
                     frust_->setLineWidth (slinef);
@@ -368,7 +378,7 @@ bool slamScene::updateScene(const MapHandler* map){
             else
             {
                 kf_pose = CPose3D( getPoseFormat( (*it)->T_kf_w ) );
-                opengl::CFrustumPtr frust_ = opengl::CFrustum::Create();
+                opengl::CFrustum::Ptr frust_ = opengl::CFrustum::Create();
                 {
                     frust_->setPose( kf_pose + frustumL_ );
                     frust_->setLineWidth (slinef);
@@ -475,7 +485,7 @@ bool slamScene::updateScene(const MapHandler* map){
         else if ( (key ==  97) || (key == 65) ){    // A        axes
             hasAxes   = !hasAxes;
             if(!hasAxes){
-                axesObj.clear();
+                axesObj.reset();
             }
             else{
                 axesObj = opengl::CAxis::Create();
@@ -488,7 +498,7 @@ bool slamScene::updateScene(const MapHandler* map){
         else if ( (key == 112) || (key == 80) ){    // P        points
             hasPoints = !hasPoints;
             if(!hasPoints){
-                elliObjP.clear();
+                elliObjP.reset();
             }
             else{
                 elliObjP = opengl::CSetOfObjects::Create();
@@ -500,7 +510,7 @@ bool slamScene::updateScene(const MapHandler* map){
         else if ( (key == 108) || (key == 76) ){    // L        lines
             hasLines  = !hasLines;
             if(!hasLines){
-                elliObjL.clear();
+                elliObjL.reset();
             }
             else{
                 elliObjL = opengl::CSetOfObjects::Create();
@@ -540,6 +550,9 @@ bool slamScene::updateScene(const MapHandler* map){
 
 bool slamScene::updateSceneSafe(const MapHandler* map){
 
+    using mrpt::img::TColor;
+    using mrpt::img::TColorf;
+
     theScene = win->get3DSceneAndLock();
     bool restart = false;
 
@@ -569,7 +582,7 @@ bool slamScene::updateSceneSafe(const MapHandler* map){
             if( (*it)->kf_idx == map->map_keyframes.back()->kf_idx )
             {
                 kf_pose = CPose3D( getPoseFormat( (*it)->T_kf_w ) );
-                opengl::CFrustumPtr frust_ = opengl::CFrustum::Create();
+                opengl::CFrustum::Ptr frust_ = opengl::CFrustum::Create();
                 {
                     frust_->setPose( kf_pose + frustumL_ );
                     frust_->setLineWidth (slinef);
@@ -607,7 +620,7 @@ bool slamScene::updateSceneSafe(const MapHandler* map){
             else
             {
                 kf_pose = CPose3D( getPoseFormat( (*it)->T_kf_w ) );
-                opengl::CFrustumPtr frust_ = opengl::CFrustum::Create();
+                opengl::CFrustum::Ptr frust_ = opengl::CFrustum::Create();
                 {
                     frust_->setPose( kf_pose + frustumL_ );
                     frust_->setLineWidth (slinef);
@@ -712,7 +725,7 @@ bool slamScene::updateSceneSafe(const MapHandler* map){
         else if ( (key ==  97) || (key == 65) ){    // A        axes
             hasAxes   = !hasAxes;
             if(!hasAxes){
-                axesObj.clear();
+                axesObj.reset();
             }
             else{
                 axesObj = opengl::CAxis::Create();
@@ -725,7 +738,7 @@ bool slamScene::updateSceneSafe(const MapHandler* map){
         else if ( (key == 112) || (key == 80) ){    // P        points
             hasPoints = !hasPoints;
             if(!hasPoints){
-                elliObjP.clear();
+                elliObjP.reset();
             }
             else{
                 elliObjP = opengl::CSetOfObjects::Create();
@@ -737,7 +750,7 @@ bool slamScene::updateSceneSafe(const MapHandler* map){
         else if ( (key == 108) || (key == 76) ){    // L        lines
             hasLines  = !hasLines;
             if(!hasLines){
-                elliObjL.clear();
+                elliObjL.reset();
             }
             else{
                 elliObjL = opengl::CSetOfObjects::Create();
@@ -777,6 +790,7 @@ bool slamScene::updateSceneSafe(const MapHandler* map){
 
 void slamScene::updateSceneGraphs( const MapHandler* map )
 {
+    using mrpt::img::TColor;
 
     // Reset scene
     theScene = win->get3DSceneAndLock();
@@ -794,7 +808,7 @@ void slamScene::updateSceneGraphs( const MapHandler* map )
         if( (*it)!=NULL )
         {
             kf_pose = CPose3D( getPoseFormat( (*it)->T_kf_w ) );
-            opengl::CFrustumPtr frust_ = opengl::CFrustum::Create();
+            opengl::CFrustum::Ptr frust_ = opengl::CFrustum::Create();
             {
                 frust_->setPose( kf_pose + frustumL_ );
                 frust_->setLineWidth (slinef);
@@ -821,7 +835,7 @@ void slamScene::updateSceneGraphs( const MapHandler* map )
                 {
                     Vector3d Pi = map->map_keyframes[i]->T_kf_w.col(3).head(3);
                     Vector3d Pj = map->map_keyframes[j]->T_kf_w.col(3).head(3);
-                    opengl::CSimpleLinePtr obj = opengl::CSimpleLine::Create();
+                    opengl::CSimpleLine::Ptr obj = opengl::CSimpleLine::Create();
                     obj->setLineCoords(Pi(0),Pi(1),Pi(2), Pj(0),Pj(1),Pj(2));
                     obj->setLineWidth(0.5f);
                     obj->setColor(0,0.5,0);
@@ -869,7 +883,7 @@ void slamScene::updateSceneGraphs( const MapHandler* map )
 
     // Update the image
     if(hasImg)
-        image->setImageView_fast( img_mrpt_image );
+        image->setImageView( std::move(img_mrpt_image) );
 
     // Re-paint the scene
     win->unlockAccess3DScene();
@@ -942,7 +956,7 @@ void slamScene::setLegend(){
         if(hasComparison){
             img_legend = "../config/aux/legend_comp.png";
             img_mrpt_legend.loadFromFile(img_legend,1);
-            legend->setImageView_fast( img_mrpt_legend );
+            legend->setImageView( std::move(img_mrpt_legend) );
         }
         else
             img_mrpt_legend.loadFromFile("",1);
@@ -950,12 +964,12 @@ void slamScene::setLegend(){
     else if(hasComparison){
         img_legend = "../config/aux/legend_full.png";
         img_mrpt_legend.loadFromFile(img_legend,1);
-        legend->setImageView_fast( img_mrpt_legend );
+        legend->setImageView( std::move(img_mrpt_legend) );
     }
     else{
         img_legend = "../config/aux/legend.png";
         img_mrpt_legend.loadFromFile(img_legend,1);
-        legend->setImageView_fast( img_mrpt_legend );
+        legend->setImageView( std::move(img_mrpt_legend) );
     }
 }
 
@@ -964,7 +978,7 @@ void slamScene::setHelp(){
     help = theScene->createViewport("help");
     img_help = "../config/aux/help.png";
     img_mrpt_help.loadFromFile(img_help,1);
-    help->setImageView_fast( img_mrpt_help );
+    help->setImageView( std::move(img_mrpt_help) );
     if(hasHelp)
         help->setViewportPosition(1600, 20, 300, 376);
     else
@@ -992,7 +1006,7 @@ void slamScene::setLines(CMatrixFloat lData_){
 
 void slamScene::setKF(Matrix4d Tfw){
     // Initialize the camera object
-    opengl::CSetOfObjectsPtr kfbb = opengl::stock_objects::BumblebeeCamera();
+    opengl::CSetOfObjects::Ptr kfbb = opengl::stock_objects::BumblebeeCamera();
     {
         CPose3D pose( getPoseFormat(Tfw) );
         kfbb->setPose( pose );
@@ -1047,6 +1061,7 @@ bool slamScene::getYPR(float &yaw, float &pitch, float &roll){
     yaw   = y;
     pitch = p;
     roll  = r;
+    return true;
 }
 
 bool slamScene::getPose(Matrix4d &T){
@@ -1057,6 +1072,7 @@ bool slamScene::getPose(Matrix4d &T){
             T(i,j) = T_(i,j);
         }
     }
+    return true;
 }
 
 }


### PR DESCRIPTION
- CMake format and style clean ups.
- Use "modern" CMake exported targets to link against g2o.
- Port mrpt-related code to work with mrpt >=1.9.9.
- Update README.md accordingly. 

Closes #30 
